### PR TITLE
#93 fix variants.py and associated parser in parser.py

### DIFF
--- a/maxatac/analyses/variants.py
+++ b/maxatac/analyses/variants.py
@@ -7,12 +7,13 @@ from maxatac.utilities.genome_tools import build_chrom_sizes_dict
 import pandas as pd
 import pybedtools
 
+
 def run_variants(args):
     """Predict TF binding using a variant call format file to make sequence specific predictions
     
     Args:
         args ([type]): input_bigwig, sequence, models, chromosomes, variant_start_pos, nucleotide, overhang, output, name
-    """    
+    """
     output_directory = get_dir(args.output)
     output_bw = os.path.join(output_directory, args.name + ".bw")
     output_bg = os.path.join(output_directory, args.name + ".bg")
@@ -22,25 +23,25 @@ def run_variants(args):
     if args.roi:
         logging.error("Import prediction regions")
         bed_df = pd.read_table(args.roi, header=None, names=["chr", "start", "stop"])
-        
+
         regions_pool = import_roi_bed(args.roi)
-        
+
         # Find the chromosomes for which we can make predictions based on the requested chroms
         # and the BED regions provided in the ROI file
         chrom_list = list(set(args.chromosomes).intersection(set(bed_df["chr"].unique())))
-        
+
     else:
         logging.error("Create prediction regions")
         bed_df = create_prediction_regions(chromosomes=args.chromosomes,
-                                                 chrom_sizes=args.chromosome_sizes,
-                                                 blacklist=args.blacklist,
-                                                 step_size=args.step_size
-                                                 )
-        
+                                           chrom_sizes=args.chrom_sizes,
+                                           blacklist=args.blacklist,
+                                           step_size=args.step_size
+                                           )
+
         regions_pool = pybedtools.BedTool.from_dataframe(bed_df)
-        
+
         chrom_list = args.chromosomes
-    
+
     logging.error(f"Making sequence specific predictions for: {args.input_bigwig} \n" +
                   f"Writing files with name: {args.name} \n" +
                   f"Output bigwig: {output_bw} \n" +
@@ -51,25 +52,24 @@ def run_variants(args):
                   f"Chromosome(s): {chrom_list} \n" +
                   f"Variants Bed: {args.variants_bed}"
                   )
-  
+
     try:
         os.mkdir(output_directory)
-    
+
     except OSError as error:
         print(error)
-    
+
     predictions = variant_specific_predict(args.model,
-                                              args.signal,
-                                              args.sequence,
-                                              regions_pool,
-                                              args.variants_bed)
-    
+                                           args.input_bigwig,
+                                           args.sequence,
+                                           regions_pool,
+                                           args.variants_bed)
+
     predictions.to_csv(output_bg, sep="\t", index=False, header=False)
-    
+
     chr_dict = build_chrom_sizes_dict(chrom_list, args.chrom_sizes)
-    
-    write_predictions_to_bigwig(predictions, 
-                        output_bw, 
-                        chrom_sizes_dictionary=chr_dict, 
-                        chromosomes=chrom_list)
-    
+
+    write_predictions_to_bigwig(predictions,
+                                output_bw,
+                                chrom_sizes_dictionary=chr_dict,
+                                chromosomes=chrom_list)

--- a/maxatac/utilities/parser.py
+++ b/maxatac/utilities/parser.py
@@ -22,7 +22,7 @@ with Mute():
     from maxatac.analyses.prepare import run_prepare
     from maxatac.analyses.threshold import run_thresholding
     from maxatac.analyses.data import run_data
-    
+
 from maxatac.utilities.constants import (DEFAULT_TRAIN_VALIDATE_CHRS,
                                          LOG_LEVELS,
                                          DEFAULT_LOG_LEVEL,
@@ -40,8 +40,8 @@ from maxatac.utilities.constants import (DEFAULT_TRAIN_VALIDATE_CHRS,
                                          BLACKLISTED_REGIONS_BIGWIG,
                                          DEFAULT_BENCHMARKING_AGGREGATION_FUNCTION,
                                          DEFAULT_BENCHMARKING_BIN_SIZE,
-                                         ALL_CHRS, 
-                                         AUTOSOMAL_CHRS, 
+                                         ALL_CHRS,
+                                         AUTOSOMAL_CHRS,
                                          REFERENCE_SEQUENCE_TWOBIT
                                          )
 
@@ -80,7 +80,7 @@ def get_parser():
     # Parent (general) parser
     parent_parser = argparse.ArgumentParser(add_help=False)
     general_parser = argparse.ArgumentParser(description="Neural networks for predicting TF binding using ATAC-seq")
-    
+
     # Add subparsers to the general parser and require that one is provided
     subparsers = general_parser.add_subparsers()
     subparsers.required = True
@@ -110,7 +110,7 @@ def get_parser():
                              required=False,
                              help="The reference genome build to download."
                             )
-    
+
     data_parser.add_argument("--output", "-o",
                              dest="output",
                              type=str,
@@ -126,7 +126,7 @@ def get_parser():
                              choices=LOG_LEVELS.keys(),
                              help="Logging level. Default: " + DEFAULT_LOG_LEVEL
                             )
-    
+
     #############################################
     # Average subparser
     #############################################
@@ -203,9 +203,9 @@ def get_parser():
                         type=str,
                         help="The TF name for prediction"
                         )
-        
-    group.add_argument("-m", "--model", 
-                        dest="model", 
+
+    group.add_argument("-m", "--model",
+                        dest="model",
                         type=str,
                         help="Trained maxATAC model .h5 file."
                         )
@@ -820,7 +820,7 @@ def get_parser():
                                  required=True,
                                  help="Output filename without extension. Example: Tcell_chr1_rs1234_CTCF"
                                 )
-    
+
     variants_parser.add_argument("-s", "--sequence",
                                  dest="sequence",
                                  default=REFERENCE_SEQUENCE_TWOBIT,
@@ -830,24 +830,23 @@ def get_parser():
 
     variants_parser.add_argument("-chroms", "--chromosomes",
                                  dest="chromosomes",
+                                 nargs="+",
                                  default=ALL_CHRS,
                                  help="Chromosomes to limit prediction to"
                                 )
 
     variants_parser.add_argument("-variants_bed", "--variants_bed",
                                  dest="variants_bed",
-                                 type=int,
                                  required=True,
                                  help="The variant start position in BED format with the nucleotide at that position"
                                 )
 
     variants_parser.add_argument("-roi", "--roi",
                                  dest="roi",
-                                 type=int,
                                  required=False,
                                  help="A bed file of LD blocks to predict in specifically"
                                 )
-      
+
     variants_parser.add_argument("--loglevel",
                                  dest="loglevel",
                                  type=str,
@@ -862,7 +861,7 @@ def get_parser():
                                  default=BLACKLISTED_REGIONS,
                                  help="The blacklisted regions to exclude in bed format."
                                 )
-    
+
     variants_parser.add_argument("--chrom_sizes",
                                  dest="chrom_sizes",
                                  type=str,
@@ -909,7 +908,7 @@ def get_parser():
                                 required=True,
                                 help="Filename prefix to use as the basename"
                                )
-    
+
     prepare_parser.add_argument("--chrom_sizes",
                                 dest="chrom_sizes",
                                 type=str,
@@ -923,14 +922,14 @@ def get_parser():
                                 default=20,
                                 help="The slop size to use around the Tn5 cut sites."
                                )
-    
+
     prepare_parser.add_argument("-rpm", "--rpm_factor",
                                 dest="rpm_factor",
                                 type=int,
                                 default=20000000,
                                 help="The RPM factor to use for scaling your read depth normalized signal."
                                )
-    
+
     prepare_parser.add_argument("--blacklist_bed",
                                 dest="blacklist_bed",
                                 type=str,
@@ -944,7 +943,7 @@ def get_parser():
                                 default=BLACKLISTED_REGIONS_BIGWIG,
                                 help="The blacklisted regions to exclude in bigwig format."
                                 )
-    
+
     prepare_parser.add_argument("-chroms", "--chromosomes",
                                 dest="chroms",
                                 type=str,
@@ -966,7 +965,7 @@ def get_parser():
                                 action="store_true",
                                 help="Whether to perform deduplication"
                                 )
-        
+
     prepare_parser.add_argument("--loglevel",
                                 dest="loglevel",
                                 type=str,


### PR DESCRIPTION
I found some additional problems that also needed corrected.
* There were a few other arguments that had the wrong `dtype`.
* The `chroms` argument was missing the `nargs='+'` argument.
* The variants.py file line 68 was also incorrect and had `args.signal` instead of `args.input_bigwig`.