### PR TITLE
#93 fix missing chrom_sizes for ROI based variant predictions

### DIFF
--- a/maxatac/analyses/variants.py
+++ b/maxatac/analyses/variants.py
@@ -24,7 +24,7 @@ def run_variants(args):
         logging.error("Import prediction regions")
         bed_df = pd.read_table(args.roi, header=None, names=["chr", "start", "stop"])
 
-        regions_pool = import_roi_bed(args.roi)
+        regions_pool = import_roi_bed(args.roi, args.chrom_sizes)
 
         # Find the chromosomes for which we can make predictions based on the requested chroms
         # and the BED regions provided in the ROI file

--- a/maxatac/utilities/variant_tools.py
+++ b/maxatac/utilities/variant_tools.py
@@ -139,7 +139,7 @@ def convert_predictions_to_bedgraph(predictions: list,
     return windowed_coordinates_dataframe
 
 
-def import_roi_bed(roi_bed):
+def import_roi_bed(roi_bed, chrom_sizes):
     """Import bed file of haplotype blocks or LD blocks
 
     Args:
@@ -149,7 +149,7 @@ def import_roi_bed(roi_bed):
         pyBedTool.BedTool: A BedTool object of regions to use for prediction
     """
     roi_bedtool = pybedtools.BedTool(roi_bed)
-    roi_bedtool_slop = roi_bedtool.slop(g=chrom_sizes,b=512)
+    roi_bedtool_slop = roi_bedtool.slop(g=chrom_sizes, b=512)
 
     roi_DF = pybedtools.BedTool().window_maker(b=roi_bedtool_slop, w=1024, s=256).to_dataframe()
     roi_DF["length"] = roi_DF["end"] - roi_DF["start"]


### PR DESCRIPTION
@hrayjones noticed that ROI based predictions using the variants function was missing the required args.chrom_sizes keywords in the import_roi_bed function of variants_tools. This keyword had to also be added to the variants.py file.