### PR TITLE
#97 Update prepare function for scATAC-seq

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,13 +128,13 @@ TF binding predictions can be made genome-wide, for a single chromosome, or, alt
 Example command for TFBS prediction across the whole genome:
 
 ```bash
-maxatac predict -tf CTCF --signal GM12878.bigwig -o outputdir/
+maxatac predict -tf CTCF --signal GM12878_IS_slop20_RP20M_minmax01.bw -o outputdir/
 ```
 
 If data has been installed with maxATAC data, then the following command will use the best model and call peaks using the TF specific threshold statistics. 
 
 ```bash
-maxatac predict -tf CTCF -s GM12878.bigwig -o outputdir/
+maxatac predict -tf CTCF -s GM12878_IS_slop20_RP20M_minmax01.bw  -o outputdir/
 ```
 
 ### Prediction in a specific genomic region(s)
@@ -142,7 +142,7 @@ maxatac predict -tf CTCF -s GM12878.bigwig -o outputdir/
 For TFBS predictions within specific regions of the genome, a `BED` file of genomic intervals, `roi` (regions of interest) are supplied:
 
 ```bash
-maxatac predict -tf CTCF --signal GM12878.bigwig --roi ROI.bed
+maxatac predict -tf CTCF --signal GM12878_IS_slop20_RP20M_minmax01.bw  --roi ROI.bed
 ```
 
 ### Prediction on a specific chromosome(s)
@@ -150,7 +150,7 @@ maxatac predict -tf CTCF --signal GM12878.bigwig --roi ROI.bed
 For TFBS predictions on a single chromosome or subset of chromosomes, these can be provided using the `--chromosomes` argument:
 
 ```bash
-maxatac predict -TF CTCF --signal GM12878.bigwig --chromosomes chr3 chr5
+maxatac predict -tf CTCF --signal GM12878_IS_slop20_RP20M_minmax01.bw  --chromosomes chr3 chr5
 ```
 
 ## Raw signal tracks (prediction bigwigs) are large

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ TF binding predictions can be made genome-wide, for a single chromosome, or, alt
 Example command for TFBS prediction across the whole genome:
 
 ```bash
-maxatac predict --sequence hg38.2bit -tf CTCF --signal GM12878.bigwig -o outputdir/
+maxatac predict -tf CTCF --signal GM12878.bigwig -o outputdir/
 ```
 
 If data has been installed with maxATAC data, then the following command will use the best model and call peaks using the TF specific threshold statistics. 
@@ -142,7 +142,7 @@ maxatac predict -tf CTCF -s GM12878.bigwig -o outputdir/
 For TFBS predictions within specific regions of the genome, a `BED` file of genomic intervals, `roi` (regions of interest) are supplied:
 
 ```bash
-maxatac predict --sequence hg38.2bit -m CTCF.h5 --signal GM12878.bigwig --roi ROI.bed
+maxatac predict -tf CTCF --signal GM12878.bigwig --roi ROI.bed
 ```
 
 ### Prediction on a specific chromosome(s)
@@ -150,7 +150,7 @@ maxatac predict --sequence hg38.2bit -m CTCF.h5 --signal GM12878.bigwig --roi RO
 For TFBS predictions on a single chromosome or subset of chromosomes, these can be provided using the `--chromosomes` argument:
 
 ```bash
-maxatac predict --sequence hg38.2bit -m CTCF.h5 --signal GM12878.bigwig --chromosomes chr3 chr5
+maxatac predict -TF CTCF --signal GM12878.bigwig --chromosomes chr3 chr5
 ```
 
 ## Raw signal tracks (prediction bigwigs) are large

--- a/docs/readme/variants.md
+++ b/docs/readme/variants.md
@@ -1,6 +1,6 @@
 # Variants
 
-The `variants` function is intended for using a maxATAC model to predict TF binding in non-overlapping LD blocks. *The function can perform whole genome prediction, but has not been optimized for that yet.* The `variants` function takes as input a bed file of variants and the nucleotide at that position along with the regions that you want to make predictions for.
+The `variants` function is intended for using a maxATAC model to predict TF binding in non-overlapping LD blocks. *The function can perform whole genome prediction, but has not been optimized for that yet.* The `variants` function takes as input a bed file of variants and the nucleotide to use at that position. You must also provide the regions that you want to make predictions in. This function will then merge nearby ROI intervals (+/- 512 bp) and create sliding windows (1,024 bp wide x 256 bp step) along the ROI. Regions at the end of the interval will be trimmmed off if they are less than 1,024 bp. 
 
 ## Example
 
@@ -34,7 +34,7 @@ This argument specifies the path to the 2bit DNA sequence for the genome of inte
 
 ### `-roi`
 
-The bed file of LD blocks that are to be predicted in. Predictions will be limited to these specific regions. Default: Whole genome prediction. 
+The bed file of intervals to use for prediction windows. Predictions will be limited to these specific regions. Only the first 3 columns of the file will be considered when making the prediction windows. Default: Whole genome prediction. 
 
 ### `-o, --output`
 

--- a/maxatac/utilities/prepare_tools.py
+++ b/maxatac/utilities/prepare_tools.py
@@ -13,20 +13,14 @@ def convert_fragments_to_tn5_bed(fragments_tsv: str, chroms: list):
     
     >>> bed_file = convert_fragments_to_tn5_bed(Granja_frags.tsv, ["chr1, "chr2"])
     """
-    col_types = {
-                 "chr": "category", 
-                 "start": "int32", 
-                 "stop": "int32", 
-                 "barcode": "category", 
-                 "support": "int32"
-                }
     
     # Import fragments tsv as a dataframe
     df = pd.read_table(fragments_tsv,
+                       sep="\t",
                        header=None,
-                       names=["chr", "start", "stop", "barcode", "support"],
-                       dtype=col_types, 
-                       low_memory=False)
+                       usecols=[0,1,2,3],
+                       names=["chr", "start", "stop", "barcode"]
+                       )
     
     df = df[df["chr"].isin(chroms)]
     

--- a/maxatac/utilities/variant_tools.py
+++ b/maxatac/utilities/variant_tools.py
@@ -139,27 +139,6 @@ def convert_predictions_to_bedgraph(predictions: list,
     return windowed_coordinates_dataframe
 
 
-def import_roi_bed(roi_bed, chrom_sizes):
-    """Import bed file of haplotype blocks or LD blocks
-
-    Args:
-        roi_bed (str): Path to the bedfile with region information
-
-    Returns:
-        pyBedTool.BedTool: A BedTool object of regions to use for prediction
-    """
-    roi_bedtool = pybedtools.BedTool(roi_bed)
-    roi_bedtool_slop = roi_bedtool.slop(g=chrom_sizes, b=512)
-
-    roi_DF = pybedtools.BedTool().window_maker(b=roi_bedtool_slop, w=1024, s=256).to_dataframe()
-    roi_DF["length"] = roi_DF["end"] - roi_DF["start"]
-    roi_DF = roi_DF[roi_DF["length"] == 1024]
-    
-    roi_BT = pybedtools.BedTool.from_dataframe(roi_DF[["chrom", "start", "end"]])
-
-    return roi_BT
-
-
 def variant_specific_predict(model:str,
             signal:str,
             sequence:str,


### PR DESCRIPTION
Update code for preparing scATAC-seq fragment files related to #97 . There was an issue where the fragments files could not be read in as a dataframe. I am not sure what caused this to be an issue now when we have used this function previously. I added code to import the dataframe that seemed to work. This needs to be tested with another fragment file and validated that it works.