### PR TITLE
101 roi generator, documentation, and get_target_matrix function added

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ ___
 
 It is best to install maxATAC into a dedicated virtual environment.
 
-This version requires python 3.9, `bedtools`, `samtools`, `pigz`, `wget`, `git`, and `bedGraphToBigWig` in order to run all functions.
+This version requires python 3.9, `bedtools`, `samtools`, `pigz`, `wget`, `git`, `graphviz`, and `bedGraphToBigWig` in order to run all functions.
 
 > The total install requirements for maxATAC with reference data are ~2 GB.
 
@@ -31,12 +31,15 @@ This version requires python 3.9, `bedtools`, `samtools`, `pigz`, `wget`, `git`,
 
 > If you get an error installing ucsc-bedgraphtobigwig try `conda install -c bioconda ucsc-bedgraphtobigwig`
 
+> If you get an error regarding graphviz while training a model, re-install graphviz with `conda install graphviz`
+
 2. Install maxATAC with `pip install maxatac`
 
 3. Test installation with `maxatac -h`
 
 4. Download reference data with `maxatac data`
 
+> If you have an error related to pybigwig, reference issues: [96](https://github.com/MiraldiLab/maxATAC/issues/96) and [87](https://github.com/MiraldiLab/maxATAC/issues/87#issue-1139117054)
 ### Installing with python virtualenv
 
 1. Create a virtual environment for maxATAC with `virtualenv -p python3.9 maxatac`.
@@ -60,7 +63,7 @@ In order to run the maxATAC models that were described in the [maxATAC pre-print
 * TF specific thresholding files
 * Bash scripts for preparing data
 
-The easiest option is to use the command `maxatac data` to download the data to the required directory. The `maxatac data` function will download the maxATAC_data repo and reference data into your `~/opt/` directory under `~/opt/maxatac`. Only the hg38 reference genome is supported.
+The easiest option is to use the command `maxatac data` to download the data to the required directory. The `maxatac data` function will download the maxATAC_data repo and reference data into your `~/opt/` directory under `~/opt/maxatac`. Only the hg38 reference genome has been extensively tested.
 
 #### Using custom reference data
 

--- a/maxatac/utilities/parser.py
+++ b/maxatac/utilities/parser.py
@@ -523,6 +523,27 @@ def get_parser():
                               default=10,
                               help="The max number of workers to spin up. These workers will load data and wait for fit."
                               )
+
+    train_parser.add_argument("--save_roi",
+                              dest="save_roi",
+                              action="store_true",
+                              default=False,
+                              help="If multiprocessing, then use multiprocessing with tf.keras.fit()"
+                              )
+
+    train_parser.add_argument("--blacklist",
+                              dest="blacklist",
+                              type=str,
+                              default=BLACKLISTED_REGIONS,
+                              help="Blacklist regions to exclude"
+                              )
+
+    train_parser.add_argument("--chrom_sizes",
+                              dest="chrom_sizes",
+                              type=str,
+                              default=DEFAULT_CHROM_SIZES,
+                              help="Chromosome sizes file"
+                              )
     #############################################
     # Normalize parser
     #############################################
@@ -1094,8 +1115,8 @@ def parse_arguments(argsl, cwd_abs_path=None):
                 "chroms", "keep", "epochs", "batches", "max_queue_size",
                 "prefix", "plot", "lrate", "decay", "bin",
                 "minimum", "test_cell_lines", "rand_ratio",
-                "train_tf", "arch", "batch_size",
-                "val_batch_size", "target_scale_factor",
+                "train_tf", "arch", "batch_size", "save_roi",
+                "val_batch_size", "target_scale_factor", "blacklist",
                 "output_activation", "dense", "shuffle_cell_type", "rev_comp"
             ],
             cwd_abs_path


### PR DESCRIPTION
These updates involve updates to documentation, the ROI pool generator, and the function for getting the target input matrix. Changes to the data generator include removing hardcoded chromosome sizes and blacklists paths. There are some quality of life changes to the functions for getting target matrix. They were split into their own function for easier manipulation in later versions. 

I added documentation referencing issue #100 . 

The ROI pools will only be saved if you include the `--save_roi` flag is included. This was added to help with debugging and saving several versions of the same ROIs. 