### PR TITLE
Update parser.py

### DIFF
--- a/maxatac/utilities/parser.py
+++ b/maxatac/utilities/parser.py
@@ -757,12 +757,12 @@ def get_parser():
                                   help="The blacklisted regions to exclude in BigWig format"
                                   )
 
-    benchmark_parser.add_argument("-skip_plot", "--skip_plot",
-                                dest="skip_plot",
+    benchmark_parser.add_argument("-plot", "--plot",
+                                dest="plot",
                                 action="store_true",
                                 default=False,
                                 required=False,
-                                help="Skip PR curve plotting"
+                                help="Plot the PR curve."
                                 )
     #############################################
     # Peaks subparser


### PR DESCRIPTION
Fixed issue regarding plotting of PR curves via maxATAC benchmark(). Previously, a "--skip_plot" option was set by default to TRUE, so the maxATAC benchmark function would not output a P-R curve. This option has now been changed to the --plot or -plot option. When this option is included as part of a call to maxATAC benchmark(), an output PR curve will now be generated. An example plot is attached.

![MAZ_test_MCF-7_benchmark_chr2_200bp_PRC](https://github.com/user-attachments/assets/1be82f87-8bbb-49f7-92f9-26e9314b09a8)