### PR TITLE
Update threshold.py

### DIFF
--- a/maxatac/analyses/threshold.py
+++ b/maxatac/analyses/threshold.py
@@ -140,7 +140,7 @@ def run_thresholding(args):
     del PR_CURVE_DF['Random_Precision']
     
 
-    PR_CURVE_DF.columns = 	['Monotonic_Precision', 'Monotonic_Recall', 'Threshold', 'Monotonic_log2FC', 'Monotonic_F1']
+    PR_CURVE_DF.columns = ['Monotonic_Avg_Precision', 'Monotonic_Avg_Recall', 'Standard_Thresh', 'Monotonic_Avg_log2FC', 'Avg_F1']
     PR_CURVE_DF.to_csv(results_filename, sep="\t", header=True, index=False)
     
     


### PR DESCRIPTION
**_Issue_**: 

- `maxatac predict` expects the following column names in a cutoff file: 
    - 'Monotonic_Avg_Precision', 'Monotonic_Avg_Recall', 'Standard_Thresh', 'Monotonic_Avg_log2FC', 'Avg_F1'. 

-  However, `maxatac threshold` outputs a file with the following column names: 
    - 'Monotonic_Precision', 'Monotonic_Recall', 'Threshold', 'Monotonic_log2FC', 'Monotonic_F1'. 

- When these columns are not available, `maxatac predict` will not output a BED file of TFBS predictions, even when a cutoff file and type are specified by the user.

**_Fix_**:  
- I changed the column names in line 143 to correspond to the expected column names for `maxatac predict`.

I tested this change to ensure it works with v1.0.6 of maxATAC. A BED file of predictions is now outputted when a cutoff file and type are specified by the user.