### PR TITLE
Update normalize.py

### DIFF
--- a/maxatac/analyses/normalize.py
+++ b/maxatac/analyses/normalize.py
@@ -30,7 +30,7 @@ def run_normalization(args):
     3) Find the genomic min and max values by looping through each chromosome
     5) Loop through each chromosome and minmax normalize the values based on the genomic values.
 
-    :param args: signal, output_dir, chromosome_sizes, chromosomes, max_percentile, method, blacklist
+    :param args: signal, output_dir, chromosome_sizes, chromosomes, max_percentile, method, blacklist, max_zooms
 
     :return: A minmax normalized bigwig file
     """
@@ -83,7 +83,7 @@ def run_normalization(args):
     with pyBigWig.open(args.signal) as input_bw, pyBigWig.open(output_filename, "w") as output_bw:
         header = [(x, chromosome_length_dictionary[x]) for x in sorted(args.chromosomes)]
 
-        output_bw.addHeader(header)
+        output_bw.addHeader(header, maxZooms = args.max_zooms)
 
         # For every chromosome in header, perform normalization
         for chrom_name, chrom_length in header:
@@ -115,7 +115,7 @@ def run_normalization(args):
                                  ends=chrom_length,
                                  span=1,
                                  step=1,
-                                 values=normalized_signal.tolist()
+                                 values=normalized_signal.astype(np.float16).tolist()
                                  )
 
     # Measure time of averaging


### PR DESCRIPTION
**Issue**: the default behavior of maxATAC functions that generate averaged/normalized bigWig files is to generate bigWig files with 10 zoom levels (i.e., pre-computed summary statistics that enable quick zooming of bigWig files). This is extremely memory-intensive, but lower values of this parameter result in delayed loading of files in e.g., IGV.

**Solution**: 
1. Added a new argument ("max_zooms") for the maxATAC `average` and `normalize` functions in parser.py, which defaults to 5. This will allow users to specify how many zoom levels they wish to retain in the final bigWig file (0-10). I successfully tested the argument for the above functions by specifying --max_zooms 5 in my function call. 
2.  Also added code to convert values in the array used to generate the bigWig file from FP32 to FP16 values. This code was also successfully tested and resulted in additional memory savings of ~4%.