### PR TITLE
Update prepare.py

### DIFF
--- a/maxatac/analyses/prepare.py
+++ b/maxatac/analyses/prepare.py
@@ -154,6 +154,7 @@ def run_prepare(args):
     args.max = False
     args.max_percentile = 99
     args.clip = False
+    args.max_zooms = 5
     
     # Minmax normalize signal tracks
     run_normalization(args)


### PR DESCRIPTION
**Issue**: the default behavior of maxATAC functions that generate averaged/normalized bigWig files is to generate bigWig files with 10 zoom levels (i.e., pre-computed summary statistics that enable quick zooming of bigWig files). This is extremely memory-intensive, but lower values of this parameter result in delayed loading of files in e.g., IGV.

**Solution**:
1. Added a new argument ("max_zooms") for the maxATAC average and normalize functions in parser.py, which defaults to 5. This will allow users to specify how many zoom levels they wish to retain in the final bigWig file (0-10). I successfully tested the argument for the above functions by specifying --max_zooms 5 in my function call. 
2. Also added code to convert values in the array used to generate the bigWig file from FP32 to FP16 values. This code was also successfully tested and resulted in additional memory savings of ~4%.

_Note_: the only change made to this script added an explicit argument for the new max_zooms parameter to be passed into the call to normalize().