### PR TITLE
Update average.py

### DIFF
--- a/maxatac/analyses/average.py
+++ b/maxatac/analyses/average.py
@@ -24,7 +24,7 @@ def run_averaging(args):
     4) Loop through each entry in the chromosome sizes dictionary and calculate the average across all inputs
     5) Write the bigwig file
 
-    :param args: bigwig_files, output_dir, name, chromosomes, chromosome_sizes
+    :param args: bigwig_files, output_dir, name, chromosomes, chromosome_sizes, max_zooms
 
     :return: A bigwig file
     """
@@ -60,7 +60,7 @@ def run_averaging(args):
         header = [(x, chromosome_sizes_dictionary[x]) for x in sorted(args.chromosomes)]
 
         # Write the header to the file
-        output_bw.addHeader(header)
+        output_bw.addHeader(header, maxZooms = args.max_zooms)
 
         # TODO Use parallel processing to speed up. Must write chromosomes in same order as header
         # Loop through the chromosomes and average the values across files
@@ -86,7 +86,7 @@ def run_averaging(args):
                 ends=chrom_length,
                 span=1,
                 step=1,
-                values=chrom_vals.tolist()
+                values=chrom_vals.astype(np.float16).tolist()
             )
 
     # Measure time of averaging


### PR DESCRIPTION
**Issue**: the default behavior of maxATAC functions that generate averaged/normalized bigWig files is to generate bigWig files with 10 zoom levels (i.e., pre-computed summary statistics that enable quick zooming of bigWig files). This is extremely memory-intensive, but lower values of this parameter result in delayed loading of files in e.g., IGV.

**Solution**:
1. Added a new argument ("max_zooms") for the maxATAC `average` and `normalize` functions in parser.py, which defaults to 5. This will allow users to specify how many zoom levels they wish to retain in the final bigWig file (0-10). I successfully tested the argument for the above functions by specifying --max_zooms 5 in my function call. 
2. Also added code to convert values in the array used to generate the bigWig file from FP32 to FP16 values. This code was also successfully tested and resulted in additional memory savings of ~4%.