### PR TITLE
Update threshold.py

### DIFF
--- a/maxatac/analyses/threshold.py
+++ b/maxatac/analyses/threshold.py
@@ -143,7 +143,10 @@ def run_thresholding(args):
     PR_CURVE_DF.columns = 	['Monotonic_Precision', 'Monotonic_Recall', 'Threshold', 'Monotonic_log2FC', 'Monotonic_F1']
     PR_CURVE_DF.to_csv(results_filename, sep="\t", header=True, index=False)
     
-    
+    logging.info("Plot the validation statistics v. threshold values.")
+    plot_threshold_calibration_stats(PR_CURVE_DF_THRESHOLD['Standard_Threshold'], PR_CURVE_DF_THRESHOLD['Monotonic_Median_Precision'], 
+                                     PR_CURVE_DF_THRESHOLD['Monotonic_Median_Recall'], PR_CURVE_DF_THRESHOLD['Monotonic_Median_log2FC'],
+                                     PR_CURVE_DF_THRESHOLD['F1_Score'], output_dir, args.prefix)
     
     
 


### PR DESCRIPTION
**Issue**: there is currently no function to plot figures of validation performance (precision, recall, log2FC, and F1-score) v. the thresholds identified through threshold.py. Ideally, we would be able to visualize these as line plots (similar to results available in the maxATAC_data repository.

**Solution**: Added a new function to plot.py to generate a four-paneled figure with the aforementioned line plots. A matching function call was also added to threshold.py. I successfully tested this code for the TF CBX2 (sample output is displayed below).

<img width="3981" height="3539" alt="CBX2CBX2_thresholdCalibration-_validationPerformance_vs_thresholdCalibration" src="https://github.com/user-attachments/assets/e78ded1a-2c54-4cc5-9b04-6b2dc9f2ded4" />
