### PR TITLE
Update predict.py

### DIFF
--- a/maxatac/analyses/predict.py
+++ b/maxatac/analyses/predict.py
@@ -119,7 +119,8 @@ def run_prediction(args):
     write_predictions_to_bigwig(prediction_bedgraph,
                                 output_filename=outfile_name_bigwig,
                                 chrom_sizes_dictionary=chrom_sizes_dict,
-                                chromosomes=chrom_list
+                                chromosomes=chrom_list,
+                                max_zooms = args.max_zooms
                                 )
 
     # If a cutoff file is provided, call peaks
@@ -159,7 +160,6 @@ def run_prediction(args):
                   sep="\t",
                   index=False,
                   header=False)
-
 
     # Measure end time of training
     stopTime = timeit.default_timer()


### PR DESCRIPTION
**Issue**: the default behavior of maxATAC `predict` is to generate bigWig files with 10 zoom levels (i.e., pre-computed summary statistics that enable quick zooming of bigWig files). This is extremely memory-intensive, but lower values of this parameter result in delayed loading of files in e.g., IGV.

**Solution**:

1. Added a new argument ("max_zooms") for the maxATAC `predict` function in parser.py, which defaults to 5. This will allow users to specify how many zoom levels they wish to retain in the final bigWig file (0-10). I successfully tested the argument for the above functions by specifying three values of --max_zooms (1, 5, and 10) in my function call. 
3. Also added code to convert values in the array used to generate the bigWig file from FP32 to FP16 values in prediction_tools.py. This code was also successfully tested.