### PR TITLE
Update train.md

### DIFF
--- a/docs/readme/train.md
+++ b/docs/readme/train.md
@@ -110,7 +110,7 @@ The weights to use for initializing a model prior to training. Default: `do not 
 
 ### `--epochs`
 
-The number of epochs to train the model for. Default: `20`.
+The number of epochs to train the model for. Default: `100`.
 
 ### `--batches`
 


### PR DESCRIPTION
**Problem**: The published maxATAC models underwent 100 epochs of training. However, the README.md and constants.py set the default number of epochs to 20.

**Fix**: Updated the default number of epochs from 20 to 100 to match the value used in (Cazares et al., 2023).